### PR TITLE
[Target] decouple set_cuda_target_arch with autotvm

### DIFF
--- a/python/tvm/auto_scheduler/measure.py
+++ b/python/tvm/auto_scheduler/measure.py
@@ -42,7 +42,7 @@ import tvm._ffi
 from tvm.runtime import Object, module, ndarray
 from tvm.driver import build_module
 from tvm.ir import transform
-from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
+from tvm.target import set_cuda_target_arch, get_cuda_target_arch
 from tvm.autotvm.env import AutotvmGlobalScope, reset_global_scope
 from tvm.contrib import tar, ndk
 from tvm.contrib.popen_pool import PopenWorker, PopenPoolExecutor, StatusKind
@@ -551,7 +551,7 @@ class LocalRPCMeasureContext:
         from tvm.rpc.server import Server
 
         dev = tvm.device("cuda", 0)
-        if dev.exist:
+        if dev.exist and get_cuda_target_arch() is None:
             cuda_arch = "sm_" + "".join(dev.compute_version.split("."))
             set_cuda_target_arch(cuda_arch)
         self.tracker = Tracker(port=9000, port_end=10000, silent=True)

--- a/python/tvm/autotvm/env.py
+++ b/python/tvm/autotvm/env.py
@@ -24,7 +24,6 @@ class AutotvmGlobalScope(object):
         self._old = AutotvmGlobalScope.current
         AutotvmGlobalScope.current = self
 
-        self.cuda_target_arch = None
         self.in_tuning = False
         self.silent = False
 

--- a/python/tvm/meta_schedule/builder/local_builder.py
+++ b/python/tvm/meta_schedule/builder/local_builder.py
@@ -206,13 +206,13 @@ def default_build(mod: IRModule, target: Target) -> Module:
         The built Module.
     """
     # pylint: disable=import-outside-toplevel
-    from tvm.autotvm.measure.measure_methods import set_cuda_target_arch
+    from tvm.target import set_cuda_target_arch
     from tvm.driver import build as tvm_build
 
     # pylint: enable=import-outside-toplevel
 
     if target.kind.name == "cuda":
-        set_cuda_target_arch(target.attrs["arch"])
+        set_cuda_target_arch(target.arch)
 
     return tvm_build(mod, target=target)
 

--- a/python/tvm/relay/build_module.py
+++ b/python/tvm/relay/build_module.py
@@ -25,7 +25,6 @@ from tvm.ir import IRModule
 
 from tvm.ir.transform import PassContext
 from tvm.tir import expr as tvm_expr
-from tvm.target import Target
 from .. import nd as _nd, autotvm, register_func
 from ..target import Target
 from ..contrib import graph_executor as _graph_rt
@@ -225,7 +224,10 @@ class BuildModule(object):
         # Setup the params.
         if params:
             self._set_params(params)
-        mod = self._optimize(mod, target)
+
+        with target:
+            mod = self._optimize(mod, target)
+
         # Get artifacts
         params = self.get_params()
 

--- a/python/tvm/target/__init__.py
+++ b/python/tvm/target/__init__.py
@@ -72,6 +72,7 @@ from .target import (
     hexagon,
 )
 from .se_scope import make_se_scope
+from .cuda_scope import CudaGlobalScope, set_cuda_target_arch, get_cuda_target_arch
 from .compilation_config import make_compilation_config
 from .tag import list_tags
 from .generic_func import GenericFunc

--- a/python/tvm/target/cuda_scope.py
+++ b/python/tvm/target/cuda_scope.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Global configuration/variable scope for cuda target"""
+import tvm
+from tvm._ffi import register_func as _register_func
+from tvm.contrib import nvcc
+
+from .. import nd as _nd
+
+
+class CudaGlobalScope(object):
+    current = None
+
+    def __init__(self):
+        self._old = CudaGlobalScope.current
+        CudaGlobalScope.current = self
+
+        self._old_cuda_target_arch = None
+        self.cuda_target_arch = None
+
+
+CUDA_GLOBAL_SCOPE = CudaGlobalScope()
+CUDA_DEVICE_TYPE = _nd.device("cuda").device_type
+
+
+@_register_func
+def tvm_callback_cuda_compile(code):
+    """use nvcc to generate ptx code for better optimization"""
+    curr_cuda_target_arch = get_cuda_target_arch()
+    # e.g., target arch could be [
+    #   "-gencode", "arch=compute_52,code=sm_52",
+    #   "-gencode", "arch=compute_70,code=sm_70"
+    # ]
+    compile_target = "fatbin" if isinstance(curr_cuda_target_arch, list) else "ptx"
+    ptx = nvcc.compile_cuda(code, compile_target=compile_target, arch=curr_cuda_target_arch)
+    return ptx
+
+
+@_register_func("target.set_cuda_target_arch")
+def set_cuda_target_arch(arch, gencode=True):
+    """set target architecture of nvcc compiler
+
+    Parameters
+    ----------
+    arch: str or list
+        The argument of nvcc -arch. (e.g. "sm_51", "sm_62")
+        it can also be a count of gencode arguments pass to nvcc command line,
+        e.g., ["-gencode", "arch=compute_52,code=sm_52", "-gencode", "arch=compute_70,code=sm_70"]
+    """
+    if arch is None:
+        cuda_arch = None
+    elif isinstance(arch, str):
+        if gencode:
+            compute_version = arch.split('_')[1]
+            cuda_arch = [
+                "-gencode",
+                f"arch=compute_{compute_version},code=sm_{compute_version}"
+            ]
+        else:
+            cuda_arch = arch
+    elif isinstance(arch, (list, tvm.ir.container.Array)):
+        cuda_arch = list(arch)
+        assert "-gencode" in cuda_arch
+    else:
+        raise TypeError(
+            "arch is expected to be str or "
+            + "a list or NoneType, but received "
+            + "{}".format(type(arch)))
+
+    CudaGlobalScope.current._old_cuda_target_arch = get_cuda_target_arch()
+    CudaGlobalScope.current.cuda_target_arch = cuda_arch
+
+
+@_register_func("target.get_cuda_target_arch")
+def get_cuda_target_arch(target=None):
+    """get target architecture of nvcc compiler"""
+    if target is None:
+        if isinstance(CudaGlobalScope.current.cuda_target_arch, tvm.ir.container.Array):
+            return list(CudaGlobalScope.current.cuda_target_arch)
+        return CudaGlobalScope.current.cuda_target_arch
+
+    else:
+        return tvm.target.Target(target=target).arch
+
+
+@_register_func("target.reset_cuda_target_arch")
+def reset_cuda_target_arch():
+    """reset target architecture of nvcc compiler to None"""
+    CudaGlobalScope.current.cuda_target_arch = None

--- a/python/tvm/target/target.py
+++ b/python/tvm/target/target.py
@@ -24,6 +24,7 @@ import tvm._ffi
 from tvm._ffi import register_func as _register_func
 from tvm.runtime import Object
 
+from .cuda_scope import CudaGlobalScope, set_cuda_target_arch
 from . import _ffi_api
 
 
@@ -113,6 +114,8 @@ class Target(Object):
 
     def __enter__(self):
         _ffi_api.TargetEnterScope(self)
+        if self.kind.name == "cuda":
+            self.enter_cuda_scope()
         return self
 
     def __exit__(self, ptype, value, trace):
@@ -138,6 +141,14 @@ class Target(Object):
         ValueError if current target is not set.
         """
         return _ffi_api.TargetCurrent(allow_none)
+
+    def enter_cuda_scope(self):
+        if self.arch:
+            set_cuda_target_arch(self.arch)
+
+    @property
+    def arch(self):
+        return self.attrs.get("arch", None)
 
     @property
     def max_num_threads(self):


### PR DESCRIPTION
According to the troubleshooting topic [Nvcc fatal : Value ‘sm_86’ is not defined for option ‘gpu-architecture’](https://discuss.tvm.apache.org/t/nvcc-fatal-value-sm-86-is-not-defined-for-option-gpu-architecture/11422) in TVM Disscuss, this PR is aiming to find a better way to set cuda target arch out of autotvm.

Currently way to set cuda arch is too weird. The function of `set_cuda_target_arch`

